### PR TITLE
Fix seg fault calling clearok() in !usecurses case.

### DIFF
--- a/sc.c
+++ b/sc.c
@@ -395,7 +395,8 @@ main (int argc, char  **argv)
 	exit (0);
     }
 
-    clearok(stdscr, TRUE);
+    if (usecurses)
+	clearok(stdscr, TRUE);
     EvalAll();
 
     if (mopt)


### PR DESCRIPTION
Check if usecurses is set before calling clearok().  Fixes seg fault (on at least NetBSD) when using the -P or -W command line options.