### PR TITLE
Fix hang in lexer when parsing "let A0 = ."

### DIFF
--- a/lex.c
+++ b/lex.c
@@ -253,7 +253,9 @@ yylex(void)
 	    if ((!dateflag && *p=='.') || ret == FNUMBER) {
 		ret = FNUMBER;
 		yylval.fval = strtod(nstart, &p);
-		if (!
+		if (p == nstart)
+		    p++;
+		else if (!
 #ifdef HAVE_ISFINITE
 		  isfinite(
 #else


### PR DESCRIPTION
When parsing a floating point number that consists only of a single
decimal point (e.g. as `let A0 = .`), the lexer never advances past the
FNUMBER token because "." is technically an invalid floating point
number according to strtod(). strtod() doesn't perform any conversion,
and leaves `p` pointing to the ".", but returns an FNUMBER with the
value 0. On the next call to the lexer, the "." is once again parsed as
an FNUMBER with the value 0, but `p` is not updated, and we're stuck in
an endless loop.

This patch avoids the problem by skipping past the decimal point when
the strtod conversion fails. Since the lexer is already parsing the text
according to all the other rules, we should never end up at this point
in the code with any other kind of invalid input, so accepting the zero
value should not cause any unforeseen problems.