### PR TITLE
Fix -Wformat-security warnings

### DIFF
--- a/cmds.c
+++ b/cmds.c
@@ -307,15 +307,13 @@ deleterow(register int arg)
     int rs = maxrow - currow + 1;
     struct frange *fr;
     struct ent *obuf = NULL;
-    char buf[50];
 
     if ((fr = find_frange(currow, curcol)))
 	rs = fr->or_right->row - currow + 1;
     if (rs - arg < 0) {
 	rs = rs > 0 ? rs : 0;
-	snprintf(buf, sizeof buf, "Can't delete %d row%s %d row%s left", arg,
+	error("Can't delete %d row%s %d row%s left", arg,
 		(arg != 1 ? "s," : ","), rs, (rs != 1 ? "s" : ""));
-	error(buf);
 	return;
     }
     if (fr) {
@@ -448,7 +446,6 @@ void
 yankrow(int arg) {
     int rs = maxrow - currow + 1;
     int i, qtmp;
-    char buf[50];
     struct frange *fr;
     struct ent *obuf = NULL;
 
@@ -456,9 +453,8 @@ yankrow(int arg) {
 	rs = fr->or_right->row - currow + 1;
     if (rs - arg < 0) {
 	rs = rs > 0 ? rs : 0;
-	snprintf(buf, sizeof buf, "Can't yank %d row%s %d row%s left", arg,
+	error("Can't yank %d row%s %d row%s left", arg,
 		(arg != 1 ? "s," : ","), rs, (rs != 1 ? "s" : ""));
-	error(buf);
 	return;
     }
     sync_refs();
@@ -505,14 +501,12 @@ void
 yankcol(int arg) {
     int cs = maxcol - curcol + 1;
     int i, qtmp;
-    char buf[50];
     struct ent *obuf = NULL;
 
     if (cs - arg < 0) {
     	cs = cs > 0 ? cs : 0;
-	snprintf(buf, sizeof buf, "Can't yank %d column%s %d column%s left",
+	error("Can't yank %d column%s %d column%s left",
 	    arg, (arg != 1 ? "s," : ","), cs, (cs != 1 ? "s" : ""));
-	error(buf);
 	return;
     }
     sync_refs();
@@ -1177,13 +1171,11 @@ closecol(int arg)
     struct ent **pp;
     struct ent *p;
     struct ent *obuf = NULL;
-    char buf[50];
 
     if (cs - arg < 0) {
     	cs = cs > 0 ? cs : 0;
-	snprintf(buf, sizeof buf, "Can't delete %d column%s %d column%s left",
+	error("Can't delete %d column%s %d column%s left",
 	    arg, (arg != 1 ? "s," : ","), cs, (cs != 1 ? "s" : ""));
-	error(buf);
 	return;
     }
     if (any_locked_cells(0, curcol, maxrow, curcol + arg - 1)) {

--- a/gram.y
+++ b/gram.y
@@ -990,7 +990,7 @@ command:	S_LET var_or_range '=' e
 	|	S_QUERY			{ doquery(NULL, NULL, macrofd); }
 	|	S_QUERY '|' NUMBER	{ doquery(NULL, NULL, $3); }
 	|	S_GETKEY		{ dogetkey(); }
-	|	S_ERROR STRING		{ error($2); }
+	|	S_ERROR STRING		{ error("%s", $2); }
 	|	S_STATUS			{ dostat(macrofd); }
 	|	S_STATUS '|' NUMBER	{ dostat($3); }
 	|	S_RECALC		{ EvalAll();
@@ -1022,7 +1022,7 @@ command:	S_LET var_or_range '=' e
 					{ addplugin($2, $4, 'w'); } 
 	|       PLUGIN			{ *line = '|';
 					  snprintf(line + 1, sizeof(line) - 1,
-					      $1);
+					      "%s", $1);
 					  readfile(line, 0);
 					  scxfree($1); }
 	|	/* nothing */

--- a/interp.c
+++ b/interp.c
@@ -2046,7 +2046,7 @@ str_search(char *s, int firstrow, int firstcol, int lastrow, int lastcol,
 	scxfree(s);
 	tmp = scxmalloc(160);
 	regerror(errcode, &preg, tmp, sizeof(tmp));
-	error(tmp);
+	error("%s", tmp);
 	scxfree(tmp);
 	return;
     }
@@ -2054,7 +2054,7 @@ str_search(char *s, int firstrow, int firstcol, int lastrow, int lastcol,
 #if defined(RE_COMP)
     if ((tmp = re_comp(s)) != NULL) {
 	scxfree(s);
-	error(tmp);
+	error("%s", tmp);
 	return;
     }
 #endif

--- a/screen.c
+++ b/screen.c
@@ -1053,7 +1053,7 @@ update(int anychanged)		/* did any cell really change in value? */
     if (revmsg[0]) {
 	(void) move(0, 0);
 	(void) clrtoeol();	/* get rid of topline display */
-	(void) printw(revmsg);
+	(void) addstr(revmsg);
 	*revmsg = '\0';		/* don't show it again */
 	if (braille)
 	    if (message)
@@ -1074,7 +1074,7 @@ update(int anychanged)		/* did any cell really change in value? */
     if (revmsg[0]) {
 	(void) move(0, 0);
 	(void) clrtoeol();	/* get rid of topline display */
-	(void) printw(revmsg);
+	(void) addstr(revmsg);
 	*revmsg = '\0';		/* don't show it again */
 	if (braille)
 	    if (message)

--- a/vi.c
+++ b/vi.c
@@ -1540,13 +1540,13 @@ search_hist(void) {
     if ((errcode = regcomp(last_search, line, REG_EXTENDED))) {
 	char *tmp = scxmalloc(160);
 	regerror(errcode, last_search, tmp, sizeof(tmp));
-	error(tmp);
+	error("%s", tmp);
 	scxfree(tmp);
 	return;
     }
 #elif defined RE_COMP
     if ((tmp = re_comp(line)) != NULL) {
-	error(tmp);
+	error("%s", tmp);
 	return;
     }
 #elif defined REGCMP
@@ -2045,7 +2045,7 @@ query(const char *s, char *data)
 	linelim = 0;
     }
     if (s != NULL) {
-    	error(s);
+	error("%s", s);
     }
 
     while (linelim >= 0) {


### PR DESCRIPTION
Since the error() function is a printf-like function that takes a format
string, building with -Wformat-security causes warnings on some calls to
that function. Fix these calls in a few different ways depending on how
the function is used:

* When error is called after snprintf'ing into a temporary buffer, we
  can just replace the snprintf call with a call to error().
* When error is called with a single string argument a la `error(msg)`,
  it is replaced with `error("%s", msg)` to avoid potential problems.
* When printw() is called directly with a single string argument, it is
  replaced with a call to addstr() instead.