### PR TITLE
'N' command to repeat search in opposite direction

### DIFF
--- a/CHANGES-git
+++ b/CHANGES-git
@@ -1,3 +1,5 @@
+2025-06-25
+     * Add 'N' command to repeat last search in opposite direction
 2017-09-08
      * Changes to make sc build on NetBSD 1.5
        (Issue #3 reported by DNied@GitHub)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Functional extensions:
   but using the mouse requires ncurses.
   Using the mouse _wheel_ additionally requires
   ncurses version &ge; 6.)
+* Add 'N' command to repeat last search in opposite direction
 
 #### Documentation
 

--- a/gram.y
+++ b/gram.y
@@ -585,29 +585,29 @@ command:	S_LET var_or_range '=' e
 	|       S_GOTO num range	{ num_search($2,
 					  $3.left.vp->row, $3.left.vp->col,
 					  $3.right.vp->row,
-					  $3.right.vp->col, 0); }
+					  $3.right.vp->col, 0, 0); }
 	|       S_GOTO num		{ num_search($2, 0, 0,
-					  maxrow, maxcol, 0); }
+					  maxrow, maxcol, 0, 0); }
 	|       S_GOTO errlist
 	|       S_GOTO STRING range	{ str_search($2,
 					  $3.left.vp->row, $3.left.vp->col,
 					  $3.right.vp->row,
-					  $3.right.vp->col, 0); }
+					  $3.right.vp->col, 0, 0); }
 	|       S_GOTO '#' STRING range	{ str_search($3,
 					  $4.left.vp->row, $4.left.vp->col,
 					  $4.right.vp->row,
-					  $4.right.vp->col, 1); }
+					  $4.right.vp->col, 1, 0); }
 	|       S_GOTO '%' STRING range	{ str_search($3,
 					  $4.left.vp->row, $4.left.vp->col,
 					  $4.right.vp->row,
-					  $4.right.vp->col, 2); }
+					  $4.right.vp->col, 2, 0); }
 	|       S_GOTO STRING		{ str_search($2, 0, 0,
-					  maxrow, maxcol, 0); }
+					  maxrow, maxcol, 0, 0); }
 	|       S_GOTO '#' STRING	{ str_search($3, 0, 0,
-					  maxrow, maxcol, 1); }
+					  maxrow, maxcol, 1, 0); }
 	|       S_GOTO '%' STRING	{ str_search($3, 0, 0,
-					  maxrow, maxcol, 2); }
-	|	S_GOTO			{ go_last(); }
+					  maxrow, maxcol, 2, 0); }
+	|	S_GOTO			{ go_last(0); }
 	|	S_GOTO WORD		{ /* don't repeat last goto on
 						"unintelligible word" */ ; }
 	|	S_DEFINE strarg		{ struct ent_ptr arg1, arg2;
@@ -1385,13 +1385,13 @@ setitem	:	K_AUTO			{ setauto(1); }
 errlist :	K_ERROR range		{ num_search((double)0,
 					  $2.left.vp->row, $2.left.vp->col,
 					  $2.right.vp->row, $2.right.vp->col,
-					  CELLERROR); }
+					  CELLERROR, 0); }
 	|	K_ERROR			{ num_search((double)0, 0, 0,
-					  maxrow, maxcol, CELLERROR); }
+					  maxrow, maxcol, CELLERROR, 0); }
 	|	K_INVALID range		{ num_search((double)0,
 					  $2.left.vp->row, $2.left.vp->col,
 					  $2.right.vp->row, $2.right.vp->col,
-					  CELLINVALID); }
+					  CELLINVALID, 0); }
 	|	K_INVALID		{ num_search((double)0, 0, 0,
-					  maxrow, maxcol, CELLINVALID); }
+					  maxrow, maxcol, CELLINVALID, 0); }
 	;

--- a/interp.c
+++ b/interp.c
@@ -1878,7 +1878,7 @@ g_free(void)
 
 /* repeat the last goto command */
 void
-go_last(void) {
+go_last(int reverse) {
     int num = 0;
 
     switch (gs.g_type) {
@@ -1886,7 +1886,7 @@ go_last(void) {
 	    error("Nothing to repeat"); break;
 	case G_NUM:
 	    num_search(gs.g_n, gs.g_row, gs.g_col,
-		gs.g_lastrow, gs.g_lastcol, gs.errsearch);
+		gs.g_lastrow, gs.g_lastcol, gs.errsearch, reverse);
 	    break;
 	case G_CELL:
 	    moveto(gs.g_row, gs.g_col, gs.g_lastrow, gs.g_lastcol,
@@ -1899,7 +1899,7 @@ go_last(void) {
 	case G_STR: 
 	    gs.g_type = G_NONE;	/* Don't free the string */
 	    str_search(gs.g_s, gs.g_row, gs.g_col, gs.g_lastrow, gs.g_lastcol,
-		    num); 
+		    num, reverse);
 	    break;
 
 	default: error("go_last: internal error");
@@ -1958,7 +1958,7 @@ moveto(int row, int col, int lastrow, int lastcol, int cornerrow,
  */
 void
 num_search(double n, int firstrow, int firstcol, int lastrow,
-    int lastcol, int errsearch)
+    int lastcol, int errsearch, int reverse)
 {
     register struct ent *p;
     register int r,c;
@@ -1980,6 +1980,9 @@ num_search(double n, int firstrow, int firstcol, int lastrow,
 	    curcol >= firstcol && curcol <= lastcol) {
 	endr = currow;
 	endc = curcol;
+    } else if (reverse) {
+	endr = firstrow;
+	endc = firstcol;
     } else {
 	endr = lastrow;
 	endc = lastcol;
@@ -1987,16 +1990,30 @@ num_search(double n, int firstrow, int firstcol, int lastrow,
     r = endr;
     c = endc;
     while (1) {
-	if (c < lastcol)
-	    c++;
-	else {
-	    if (r < lastrow) {
-		while (++r < lastrow && row_hidden[r]) /* */;
-		c = firstcol;
-	    } else {
-		r = firstrow;
-		c = firstcol;
-	    }
+	if (reverse) {
+		if (c > firstcol)
+		    c--;
+		else {
+		    if (r > firstrow) {
+			while (--r > firstrow && row_hidden[r]) /* */;
+			c = lastcol;
+		    } else {
+			r = lastrow;
+			c = lastcol;
+		    }
+		}
+	} else {
+		if (c < lastcol)
+		    c++;
+		else {
+		    if (r < lastrow) {
+			while (++r < lastrow && row_hidden[r]) /* */;
+			c = firstcol;
+		    } else {
+			r = firstrow;
+			c = firstcol;
+		    }
+		}
 	}
 	p = *ATBL(tbl, r, c);
 	if (!col_hidden[c] && p && (p->flags & IS_VALID) &&
@@ -2028,7 +2045,7 @@ num_search(double n, int firstrow, int firstcol, int lastrow,
 /* 'goto' a cell containing a matching string */
 void
 str_search(char *s, int firstrow, int firstcol, int lastrow, int lastcol,
-	int num)
+	int num, int reverse)
 {
     struct ent	*p;
     int		r, c;
@@ -2078,6 +2095,9 @@ str_search(char *s, int firstrow, int firstcol, int lastrow, int lastcol,
 	    curcol >= firstcol && curcol <= lastcol) {
 	endr = currow;
 	endc = curcol;
+    } else if (reverse) {
+	endr = firstrow;
+	endc = firstcol;
     } else {
 	endr = lastrow;
 	endc = lastcol;
@@ -2085,16 +2105,30 @@ str_search(char *s, int firstrow, int firstcol, int lastrow, int lastcol,
     r = endr;
     c = endc;
     while (1) {
-	if (c < lastcol) {
-	    c++;
+	if (reverse) {
+		if (c > firstcol)
+		    c--;
+		else {
+		    if (r > firstrow) {
+			while (--r > firstrow && row_hidden[r]) /* */;
+			c = lastcol;
+		    } else {
+			r = lastrow;
+			c = lastcol;
+		    }
+		}
 	} else {
-	    if (r < lastrow) {
-		while (++r < lastrow && row_hidden[r]) /* */;
-		c = firstcol;
-	    } else {
-		r = firstrow;
-		c = firstcol;
-	    }
+		if (c < lastcol)
+		    c++;
+		else {
+		    if (r < lastrow) {
+			while (++r < lastrow && row_hidden[r]) /* */;
+			c = firstcol;
+		    } else {
+			r = firstrow;
+			c = firstcol;
+		    }
+		}
 	}
 	p = *ATBL(tbl, r, c);
 	if (gs.g_type == G_NSTR) {

--- a/sc.c
+++ b/sc.c
@@ -1688,7 +1688,10 @@ main (int argc, char  **argv)
 		    insert_mode();
 		    break;
 		case 'n':
-		    go_last();
+		    go_last(0);
+		    break;
+		case 'N':
+		    go_last(1);
 		    break;
 		case 'P':
 		    snprintf(line, sizeof line, "put [\"dest\" range] \"");

--- a/sc.doc
+++ b/sc.doc
@@ -1309,7 +1309,10 @@ The last
 command is saved, and can be re-issued by entering 
 .BR g <return>.
 You can also repeat the last search by pressing
-.BR n .
+.BR n
+(or
+.BR N
+to repeat the search in the opposite direction).
 .IP
 An optional second argument is available whose meaning
 depends on whether you're doing a search or jumping to a

--- a/sc.h
+++ b/sc.h
@@ -507,7 +507,7 @@ extern	void getfmt(int r0, int c0, int rn, int cn, int fd);
 extern	void getformat(int col, int fd);
 extern	void getnum(int r0, int c0, int rn, int cn, int fd);
 extern	void getstring(int r0, int c0, int rn, int cn, int fd);
-extern	void go_last(void);
+extern	void go_last(int reverse);
 extern	void goraw(void);
 extern	void help(void);
 extern	void hide_col(int arg);
@@ -534,7 +534,7 @@ extern	void moveto(int row, int col, int lastrow, int lastcol,
 	int cornrow, int corncol);
 extern	void toggle_navigate_mode(void);
 extern	void num_search(double n, int firstrow, int firstcol, int lastrow,
-	int lastcol, int errsearch);
+	int lastcol, int errsearch, int reverse);
 extern	void printfile(char *fname, int r0, int c0, int rn, int cn);
 extern	void pullcells(int to_insert);
 extern	void query(const char *s, char *data);
@@ -559,7 +559,7 @@ extern	void startshow(void);
 extern	void startdisp(void);
 extern	void stopdisp(void);
 extern	void str_search(char *s, int firstrow, int firstcol, int lastrow,
-	int lastcol, int num);
+	int lastcol, int num, int reverse);
 extern	void sync_cranges(void);
 extern	void sync_franges(void);
 extern	void sync_ranges(void);

--- a/vi.c
+++ b/vi.c
@@ -522,6 +522,7 @@ write_line(int c)
 				}
 									break;
 	case 'L':		forwcol(lcols - (curcol - stcol) + 1);	break;
+	case 'N':		go_last(1);				break;
 	case (ctl('a')):
 	case KEY_HOME:		gohome();				break;
 	case '0':		leftlimit();				break;
@@ -543,7 +544,7 @@ write_line(int c)
 	case '`': case '\'':	dotick(c);				break;
 	case '*':		if (nmgetch() == '*') gotonote();	break;
 	case 'g':		dogoto();				break;
-	case 'n':		go_last();				break;
+	case 'n':		go_last(0);				break;
 	case 'w':		{
 				register struct ent *p;
 


### PR DESCRIPTION
Reverse-repeat search using 'N' had been supported in vi mode, but not until now for search executed using the 'g' command, "go to cell". This commit makes the behavior consistent.